### PR TITLE
Changed cat() to message() in MizerParams() to clean up test output

### DIFF
--- a/R/MizerParams-class.r
+++ b/R/MizerParams-class.r
@@ -410,7 +410,10 @@ setMethod('MizerParams', signature(object='numeric', interaction='missing'),
 #' @rdname MizerParams-methods
 #' @aliases MizerParams,data.frame,matrix-method
 setMethod('MizerParams', signature(object='data.frame', interaction='matrix'),
-    function(object, interaction,  n = 2/3, p = 0.7, q = 0.8, r_pp = 10, kappa = 1e11, lambda = (2+q-n), w_pp_cutoff = 10, max_w = max(object$w_inf)*1.1, f0 = 0.6, z0pre = 0.6, z0exp = n-1, ...){
+    function(object, interaction,  n = 2/3, p = 0.7, q = 0.8, r_pp = 10, 
+             kappa = 1e11, lambda = (2+q-n), w_pp_cutoff = 10, 
+             max_w = max(object$w_inf)*1.1, f0 = 0.6, 
+             z0pre = 0.6, z0exp = n-1, ...){
 
 	# Set default values for column values if missing
 	# If no gear_name column in object, then named after species
@@ -429,11 +432,11 @@ setMethod('MizerParams', signature(object='data.frame', interaction='matrix'),
 	    object$erepro <- 1
 	# If no sel_func column in species_params, set to 'sigmoid_length'
 	if(!("sel_func" %in% colnames(object))){
-        cat("\tNote: No sel_func column in species data frame. Setting selectivity to be 'knife_edge' for all species.\n")
+        message("\tNote: No sel_func column in species data frame. Setting selectivity to be 'knife_edge' for all species.")
 	    object$sel_func <- 'knife_edge'
         # Set default selectivity size
         if(!("knife_edge_size" %in% colnames(object))){
-            cat("Note: \tNo knife_edge_size column in species data frame. Setting knife edge selectivity equal to w_mat.\n")
+            message("Note: \tNo knife_edge_size column in species data frame. Setting knife edge selectivity equal to w_mat.")
             object$knife_edge_size <- object$w_mat
         }
     }
@@ -443,7 +446,7 @@ setMethod('MizerParams', signature(object='data.frame', interaction='matrix'),
     # Sort out h column
     # If not passed in directly, is calculated from f0 and k_vb if they are also passed in
     if(!("h" %in% colnames(object))){
-        cat("Note: \tNo h column in species data frame so using f0 and k_vb to calculate it.\n")
+        message("Note: \tNo h column in species data frame so using f0 and k_vb to calculate it.")
         if(!("k_vb" %in% colnames(object))){
             stop("\t\tExcept I can't because there is no k_vb column in the species data frame")
         }
@@ -451,18 +454,18 @@ setMethod('MizerParams', signature(object='data.frame', interaction='matrix'),
     }
     # Sorting out gamma column
     if(!("gamma" %in% colnames(object))){
-        cat("Note: \tNo gamma column in species data frame so using f0, h, beta, sigma, lambda and kappa to calculate it.\n")
+        message("Note: \tNo gamma column in species data frame so using f0, h, beta, sigma, lambda and kappa to calculate it.")
         ae <- sqrt(2*pi) * object$sigma * object$beta^(lambda-2) * exp((lambda-2)^2 * object$sigma^2 / 2)
         object$gamma <- (object$h / (kappa * ae)) * (f0 / (1 - f0))
     }
     # Sort out z0 column
     if(!("z0" %in% colnames(object))){
-        cat("Note: \tNo z0 column in species data frame so using z0 = z0pre * w_inf ^ z0exp.\n")
+        message("Note: \tNo z0 column in species data frame so using z0 = z0pre * w_inf ^ z0exp.")
         object$z0 = z0pre*object$w_inf^z0exp    # background natural mortality
     }
     # Sort out ks column
     if(!("ks" %in% colnames(object))){
-        cat("Note: \tNo ks column in species data frame so using ks = h * 0.2.\n")
+        message("Note: \tNo ks column in species data frame so using ks = h * 0.2.")
         object$ks <- object$h * 0.2
     }
 


### PR DESCRIPTION
The unit tests use the MizerParams() constructor a lot with arguments that prompt a lot of messages being printed, which makes the test output difficult to read. By changing MizerParams() to use message() rather than cat() to print those messages, they get automatically supressed when running the unit tests.